### PR TITLE
Fix uninitialized file_size in RTC load

### DIFF
--- a/src/mbc.c
+++ b/src/mbc.c
@@ -451,7 +451,12 @@ int mbc_load_ram(struct mbc *mbc, const char *filename)
     }
     return 0;
   }
-
+  
+  // Get file size to check for RTC data
+  fseek(fp, 0, SEEK_END);
+  file_size = ftell(fp);
+  fseek(fp, 0, SEEK_SET);
+  
   if (fread(mbc->ram, 1, RAM_SIZE, fp) < RAM_SIZE) {
     fclose(fp);
     return 0;


### PR DESCRIPTION
The file_size variable was declared but never assigned before being checked, causing RTC data to never load from save files. Time would reset instead of advancing based on elapsed real time.

Missed this one, found it when I was experimenting with changing the MacOS time. Behavior is now as expected.