### PR TITLE
Fix ld sp,hl/imm16 to use page table for switchable WRAM banks (Fixes PKMN Crystal... others??)

### DIFF
--- a/compiler/alu.c
+++ b/compiler/alu.c
@@ -811,19 +811,19 @@ int compile_alu_op(
     case 0xe6: // and a, #nn
         emit_andi_b_dn(block, REG_68K_D_A, READ_BYTE(*src_ptr));
         (*src_ptr)++;
-        compile_set_z_flag(block);
+        compile_set_zc_flags(block);
         return 1;
 
     case 0xee: // xor a, u8
         emit_eor_b_imm_dn(block, READ_BYTE(*src_ptr), REG_68K_D_A);
         (*src_ptr)++;
-        compile_set_z_flag(block);
+        compile_set_zc_flags(block);
         return 1;
 
     case 0xf6: // or a, #imm
         emit_ori_b_dn(block, REG_68K_D_A, READ_BYTE(*src_ptr));
         (*src_ptr)++;
-        compile_set_z_flag(block);
+        compile_set_zc_flags(block);
         return 1;
 
     case 0xfe: // cp a, imm8

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -65,7 +65,7 @@
 #define JIT_CTX_DAA_STATE     56  // 2 bytes: [0]=old_A, [1]=N flag (for DAA)
 #define JIT_CTX_FRAME_CYCLES_PTR 60  // u32 *frame_cycles_ptr (dmg->frame_cycles)
 #define JIT_CTX_STOP_FUNC   64  // void *stop_func (for STOP/speed switch)
-#define JIT_CTX_UNUSED_3    68
+#define JIT_CTX_EFF_DOUBLE_SPEED 68  // u8: 1 if double speed active AND not ignored
 #define JIT_CTX_GB_SP       72  // u16: GB stack pointer value
 #define JIT_CTX_STACK_IN_RAM 76  // non-zero if A3 points to native WRAM/HRAM
 

--- a/compiler/timing.c
+++ b/compiler/timing.c
@@ -43,6 +43,11 @@ void compile_ly_wait(
     emit_move_l_dn(block, REG_68K_D_CYCLE_COUNT, 70224 + target_cycles);
     emit_sub_l_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_CYCLE_COUNT);
 
+    // double D2 if effective double speed is active (CPU cycles = 2x PPU cycles)
+    emit_tst_b_disp_an(block, JIT_CTX_EFF_DOUBLE_SPEED, REG_68K_A_CTX);
+    emit_beq_b(block, 2);
+    emit_add_l_dn_dn(block, REG_68K_D_CYCLE_COUNT, REG_68K_D_CYCLE_COUNT);
+
     // set A to the LY value we waited for
     emit_moveq_dn(block, REG_68K_D_A, wait_ly);
 
@@ -135,6 +140,11 @@ void compile_ly_wait_reg(
     emit_addi_l_dn(block, REG_68K_D_CYCLE_COUNT, 70224);
     emit_sub_l_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_CYCLE_COUNT);
 
+    // double D2 if effective double speed is active (CPU cycles = 2x PPU cycles)
+    emit_tst_b_disp_an(block, JIT_CTX_EFF_DOUBLE_SPEED, REG_68K_A_CTX);
+    emit_beq_b(block, 2);
+    emit_add_l_dn_dn(block, REG_68K_D_CYCLE_COUNT, REG_68K_D_CYCLE_COUNT);
+
     // restore wait_ly from stack into A register
     emit_pop_l_dn(block, REG_68K_D_A);
 
@@ -176,6 +186,11 @@ void compile_halt(struct code_block *block, int next_pc)
     // in vblank: d2 = (70224 - frame_cycles) + 65664
     emit_move_l_dn(block, REG_68K_D_CYCLE_COUNT, 70224 + 65664);
     emit_sub_l_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_CYCLE_COUNT);
+
+    // double D2 if effective double speed is active (CPU cycles = 2x PPU cycles)
+    emit_tst_b_disp_an(block, JIT_CTX_EFF_DOUBLE_SPEED, REG_68K_A_CTX);
+    emit_beq_b(block, 2);
+    emit_add_l_dn_dn(block, REG_68K_D_CYCLE_COUNT, REG_68K_D_CYCLE_COUNT);
 
     // exit to C
     emit_move_l_dn(block, REG_68K_D_NEXT_PC, next_pc);

--- a/src/cgb.h
+++ b/src/cgb.h
@@ -52,6 +52,7 @@ struct cgb_state {
     // HDMA state
     u8 hdma_active;        // 1 if HDMA transfer is in progress
     u8 hdma_remaining;     // Blocks remaining - 1 (0 = 1 block left)
+    u8 hdma_completed;     // 1 if HDMA just completed naturally (batch processing guard)
     u16 hdma_source;       // Current source address (updated during transfer)
     u16 hdma_dest;         // Current destination address (updated during transfer)
     u8 hdma_last_ly;       // Last LY that triggered HDMA (0xFF = none this frame)

--- a/src/dmg.c
+++ b/src/dmg.c
@@ -388,7 +388,7 @@ void dmg_write16(void *_dmg, u16 address, u16 data)
 }
 
 // HDMA sync - triggers HDMA transfers for any lines we've crossed
-static void hdma_sync(struct dmg *dmg)
+void hdma_sync(struct dmg *dmg)
 {
     u8 current_ly;
     u8 start_ly;
@@ -532,9 +532,10 @@ void dmg_sync_hw(struct dmg *dmg, int cycles)
         dmg->lazy_ly = 0;
         dmg->ly_read_cycle = 0;
 
-        // Reset HDMA line tracking for new frame
+		// Reset HDMA line tracking for new frame
         if (dmg->cgb) {
             dmg->cgb->hdma_last_ly = 0xff;
+            dmg->cgb->hdma_completed = 0;
         }
     }
 }

--- a/src/dmg.h
+++ b/src/dmg.h
@@ -86,6 +86,8 @@ void dmg_write_slow(struct dmg *dmg, u16 address, u8 data);
 
 void dmg_sync_hw(struct dmg *dmg, int cycles);
 
+void hdma_sync(struct dmg *dmg);
+
 // page table management
 void dmg_init_pages(struct dmg *dmg);
 void dmg_update_rom_bank(struct dmg *dmg, int bank);

--- a/system6/emulator.c
+++ b/system6/emulator.c
@@ -421,10 +421,13 @@ static void UpdateMenuItems(void)
       CheckItem(menu, EDIT_GBC_MODE, gbc_enabled);
     }
     DisableItem(menu, EDIT_GBC_MODE);
+    // Ignore Double Speed only takes effect on speed switch, so disable while running
+    DisableItem(menu, EDIT_IGNORE_DOUBLE_SPEED);
   } else {
     // no game loaded, CGB can be adjusted freely
     EnableItem(menu, EDIT_GBC_MODE);
     CheckItem(menu, EDIT_GBC_MODE, gbc_enabled);
+    EnableItem(menu, EDIT_IGNORE_DOUBLE_SPEED);
   }
 }
 

--- a/system6/jit.c
+++ b/system6/jit.c
@@ -14,6 +14,7 @@
 #include "rom.h"
 #include "dispatcher_asm.h"
 #include "emulator.h"
+#include "settings.h"
 #include "debug.h"
 #include "arena.h"
 #include "cpu_cache.h"
@@ -90,7 +91,8 @@ static void sync_cache_pointers(void)
 static int jit_handle_stop(struct dmg *dmg)
 {
   if (dmg->cgb && cgb_speed_switch(dmg->cgb)) {
-    // Speed switched successfully, continue execution
+    // Speed switched successfully - update effective_double_speed
+    jit_ctx.effective_double_speed = (dmg->cgb->double_speed && !ignore_double_speed) ? 1 : 0;
     return 0;
   }
   // DMG mode or speed switch not armed - halt
@@ -141,6 +143,7 @@ void jit_init(struct dmg *dmg)
   jit_ctx.frame_cycles_ptr = &dmg->frame_cycles;
   jit_ctx.gb_sp = 0xfffe;  // initial SP (HRAM)
   jit_ctx.stack_in_ram = 1;   // fast mode - A3 points to native HRAM
+  jit_ctx.effective_double_speed = 0;
   sync_cache_pointers();
 
   jit_regs.d3 = 0x100; // initial PC

--- a/system6/jit.h
+++ b/system6/jit.h
@@ -27,7 +27,8 @@ typedef struct {
     /* 38 */ u32 _pad2;
     /* 3c */ u32 *frame_cycles_ptr; // pointer to dmg->frame_cycles for HALT
     /* 40 */ void *stop_func;  // STOP handler (for CGB speed switch)
-    /* 44 */ u32 temp2;
+    /* 44 */ volatile u8 effective_double_speed;  // 1 when cgb double_speed && !ignore_double_speed
+    /* 45 */ u8 _pad4[3];
     /* 48 */ u16 gb_sp; // GB stack pointer value (always valid)
     /* 4a */ u16 _pad3;
     /* 4c */ long stack_in_ram; // non-zero if A3 points to native WRAM/HRAM


### PR DESCRIPTION
 Finally figured this out.
 
<img width="325" height="302" alt="Screenshot 2026-02-06 at 1 10 23 PM" src="https://github.com/user-attachments/assets/e23f1985-5652-4d04-a153-05174b501752" />

  ld sp,hl and ld sp,imm16 computed the native SP pointer using a fixed
  base (dmg->main_ram), which always resolved to WRAM bank 1 for the
  $D000-$DFFF range. On CGB, this range is switchable (banks 1-7 via
  SVBK). Games like Pokemon Crystal that use the SP trick to bulk-copy
  data from switchable WRAM to VRAM would read from the wrong bank,
  causing VRAM tile corruption.

  Use the read page table at runtime instead, which is kept in sync with
  the current WRAM bank by cgb_update_wram_bank().