### PR TITLE
Fix/cpu flag correctness

### DIFF
--- a/compiler/alu.c
+++ b/compiler/alu.c
@@ -62,6 +62,11 @@ static int daa_track_needed(
 // set per-op by compile_alu_op from the scan above
 static int daa_track = 1;
 
+// bits in JIT_CTX_DAA_STATE + 1
+#define DAA_N       0x01  // last tracked op was a subtraction
+#define DAA_H_KNOWN 0x02  // bit 4 holds a computed H, do not reconstruct
+#define DAA_H       0x10  // half carry, only meaningful with DAA_H_KNOWN
+
 // DAA tracking: save old_A and set N flag before ALU ops that affect A
 // These are needed for DAA to compute the half-carry (H) and know add vs sub
 static void compile_daa_track_add(struct code_block *block)
@@ -82,8 +87,43 @@ static void compile_daa_track_sub(struct code_block *block)
     // Save old_A to context for H flag computation
     emit_move_b_dn_disp_an(block, REG_68K_D_A, JIT_CTX_DAA_STATE, REG_68K_A_CTX);
     // Set N=1 (subtraction)
-    emit_moveq_dn(block, REG_68K_D_SCRATCH_0, 1);
+    emit_moveq_dn(block, REG_68K_D_SCRATCH_0, DAA_N);
     emit_move_b_dn_disp_an(block, REG_68K_D_SCRATCH_0, JIT_CTX_DAA_STATE + 1, REG_68K_A_CTX);
+}
+
+// adc/sbc record H directly instead of leaving it to be reconstructed from
+// old_A. Reconstruction compares the result's low nibble against old_A's,
+// which is ambiguous when the operand's low nibble is $f and carry-in is
+// set: the nibble sum is exactly 16, so the result's low nibble equals
+// old_A's and the wrap test cannot tell that from "nothing changed". H came
+// out 0 when it should be 1 and daa then adjusted A by 6 too little.
+//
+// For both addition and subtraction the carry (borrow) out of bit 3 is bit 4
+// of operand_a ^ operand_b ^ result, which holds for any carry-in. Stash
+// the raw operand in D3, then fold in A and the result.
+static void compile_daa_seed_operand(struct code_block *block, uint8_t operand_reg)
+{
+    if (!daa_track)
+        return;
+    emit_move_b_dn_dn(block, operand_reg, REG_68K_D_NEXT_PC);
+}
+
+static void compile_daa_store_h(
+    struct code_block *block,
+    uint8_t old_a_reg,
+    uint8_t result_reg,
+    uint8_t n_flag
+) {
+    if (!daa_track)
+        return;
+    emit_eor_b_dn_dn(block, old_a_reg, REG_68K_D_NEXT_PC);
+    emit_eor_b_dn_dn(block, result_reg, REG_68K_D_NEXT_PC);
+    emit_andi_b_dn(block, REG_68K_D_NEXT_PC, DAA_H);
+    // D3 is exactly 0 or DAA_H now, so addq folds in the marker bits
+    emit_addq_b_dn(block, REG_68K_D_NEXT_PC, DAA_H_KNOWN | n_flag);
+    emit_move_b_dn_disp_an(block, REG_68K_D_NEXT_PC, JIT_CTX_DAA_STATE + 1, REG_68K_A_CTX);
+    // old_A in JIT_CTX_DAA_STATE is deliberately left stale: with
+    // DAA_H_KNOWN set, compile_daa never reads it
 }
 
 // DAA - Decimal Adjust Accumulator
@@ -92,6 +132,7 @@ static void compile_daa(struct code_block *block)
 {
     size_t branch_to_sub, branch_add_h_done;
     size_t branch_to_finish;
+    size_t have_h, h_set, h_clear;
     size_t skip;
 
     // Save original A lower nibble into D1 for H computation later
@@ -99,9 +140,10 @@ static void compile_daa(struct code_block *block)
     emit_move_b_dn_dn(block, REG_68K_D_A, REG_68K_D_SCRATCH_1);
     emit_andi_b_dn(block, REG_68K_D_SCRATCH_1, 0x0F);  // D1 = original A & 0xF
 
-    // Load N flag into D0 and test it (we'll reload old_A later in each path)
+    // D0 = DAA state flags; stays live across both paths, so the H
+    // reconstruction below loads old_A into D3 instead
     emit_move_b_disp_an_dn(block, JIT_CTX_DAA_STATE + 1, REG_68K_A_CTX, REG_68K_D_SCRATCH_0);
-    emit_tst_b_dn(block, REG_68K_D_SCRATCH_0);
+    emit_btst_imm_dn(block, 0, REG_68K_D_SCRATCH_0);  // DAA_N
     branch_to_sub = block->length;
     emit_bne_b(block, 0);  // branch to subtraction path if N=1
 
@@ -120,20 +162,34 @@ static void compile_daa(struct code_block *block)
     patch_branch_b(block, skip);
 
     // Now check H || (A & 0x0F) > 9 -> add 0x06
-    // Load old_A into D0 for H computation
-    emit_move_b_disp_an_dn(block, JIT_CTX_DAA_STATE, REG_68K_A_CTX, REG_68K_D_SCRATCH_0);
-    // D0 = old_A, D1 = original A & 0xF
-    // Compute H: D1 < (D0 & 0xF)?
-    emit_andi_b_dn(block, REG_68K_D_SCRATCH_0, 0x0F);  // D0 = old_A & 0xF
-    emit_cmp_b_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_SCRATCH_1);  // cmp D0, D1
+    emit_btst_imm_dn(block, 1, REG_68K_D_SCRATCH_0);  // DAA_H_KNOWN
+    have_h = block->length;
+    emit_bne_b(block, 0);
+
+    // Reconstruct H from old_A: D3 = old_A & 0xF, D1 = original A & 0xF,
+    // H = D1 < D3. Exact for add/sub/inc/dec, which have no carry-in.
+    emit_move_b_disp_an_dn(block, JIT_CTX_DAA_STATE, REG_68K_A_CTX, REG_68K_D_NEXT_PC);
+    emit_andi_b_dn(block, REG_68K_D_NEXT_PC, 0x0F);
+    emit_cmp_b_dn_dn(block, REG_68K_D_NEXT_PC, REG_68K_D_SCRATCH_1);  // cmp D3, D1
+    h_clear = block->length;
+    emit_bcc_s(block, 0);  // if D1 >= D3 (carry clear), H=0, check nibble value
+    h_set = block->length;
+    emit_bra_b(block, 0);
+
+    // H recorded by adc
+    patch_branch_b(block, have_h);
+    emit_btst_imm_dn(block, 4, REG_68K_D_SCRATCH_0);  // DAA_H
     skip = block->length;
-    emit_bcc_s(block, 0);  // if D1 >= D0 (carry clear), H=0, check nibble value
+    emit_beq_b(block, 0);
+
     // H=1, add 0x06
+    patch_branch_b(block, h_set);
     emit_addi_b_dn(block, REG_68K_D_A, 0x06);
     branch_add_h_done = block->length;
     emit_bra_b(block, 0);  // skip to finish
 
     // H=0, check if original (A & 0x0F) > 9 (D1 still has this value)
+    patch_branch_b(block, h_clear);
     patch_branch_b(block, skip);
     emit_cmp_b_imm_dn(block, REG_68K_D_SCRATCH_1, 0x09);
     skip = block->length;
@@ -154,14 +210,29 @@ static void compile_daa(struct code_block *block)
     emit_subi_b_dn(block, REG_68K_D_A, 0x60);
     patch_branch_b(block, skip);
 
-    // Compute H: D1 > (old_A & 0xF) for subtraction
-    // Load old_A & 0xF into D0
-    emit_move_b_disp_an_dn(block, JIT_CTX_DAA_STATE, REG_68K_A_CTX, REG_68K_D_SCRATCH_0);
-    emit_andi_b_dn(block, REG_68K_D_SCRATCH_0, 0x0F);  // D0 = old_A & 0xF
-    emit_cmp_b_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_SCRATCH_1);  // cmp D0, D1
+    // H -> sub 0x06
+    emit_btst_imm_dn(block, 1, REG_68K_D_SCRATCH_0);  // DAA_H_KNOWN
+    have_h = block->length;
+    emit_bne_b(block, 0);
+
+    // Reconstruct H: D1 > (old_A & 0xF) for subtraction
+    emit_move_b_disp_an_dn(block, JIT_CTX_DAA_STATE, REG_68K_A_CTX, REG_68K_D_NEXT_PC);
+    emit_andi_b_dn(block, REG_68K_D_NEXT_PC, 0x0F);
+    emit_cmp_b_dn_dn(block, REG_68K_D_NEXT_PC, REG_68K_D_SCRATCH_1);  // cmp D3, D1
+    h_clear = block->length;
+    emit_bls_b(block, 0);  // if D1 <= D3 (lower or same), no H, skip
+    h_set = block->length;
+    emit_bra_b(block, 0);
+
+    // H recorded by sbc
+    patch_branch_b(block, have_h);
+    emit_btst_imm_dn(block, 4, REG_68K_D_SCRATCH_0);  // DAA_H
     skip = block->length;
-    emit_bls_b(block, 0);  // if D1 <= D0 (lower or same), no H, skip
+    emit_beq_b(block, 0);
+
+    patch_branch_b(block, h_set);
     emit_subi_b_dn(block, REG_68K_D_A, 0x06);
+    patch_branch_b(block, h_clear);
     patch_branch_b(block, skip);
 
     // === Finish: set Z flag === (sub path falls through)
@@ -181,9 +252,6 @@ static void compile_daa(struct code_block *block)
 // Does A = A + D1 + carry using 16-bit arithmetic
 static void compile_adc_core(struct code_block *block)
 {
-    // Track for DAA: save old_A and set N=0 (addition)
-    compile_daa_track_add(block);
-
     // Zero-extend operand: andi.w #0xff, D1
     emit_andi_w_dn(block, REG_68K_D_SCRATCH_1, 0x00ff);
 
@@ -198,13 +266,20 @@ static void compile_adc_core(struct code_block *block)
     emit_addq_w_dn(block, REG_68K_D_SCRATCH_0, 1);
     patch_branch_b(block, no_carry);
 
+    // Track for DAA: D1 is still the raw operand and D4 is still old_A
+    compile_daa_seed_operand(block, REG_68K_D_SCRATCH_1);
+
     // Add operand: add.w D1, D0
     emit_add_w_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_SCRATCH_0);
+
+    // Record H before the result overwrites old_A (clobbers the CCR, which
+    // nothing below needs - tst.b re-establishes it)
+    compile_daa_store_h(block, REG_68K_D_A, REG_68K_D_SCRATCH_0, 0);
 
     // Store result: move.b D0, D4
     emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_A);
 
-    // Set flags 
+    // Set flags
     // Z from 8-bit result, C from bit 8 of 16-bit result
     emit_tst_b_dn(block, REG_68K_D_A);
     emit_move_sr_dn(block, REG_68K_D_FLAGS);     // save Z
@@ -217,15 +292,16 @@ static void compile_adc_core(struct code_block *block)
 // Does A = A - D1 - carry using 16-bit arithmetic
 static void compile_sbc_core(struct code_block *block)
 {
-    // Track for DAA: save old_A and set N=1 (subtraction)
-    compile_daa_track_sub(block);
-
     // Zero-extend operand: andi.w #0xff, D1
     emit_andi_w_dn(block, REG_68K_D_SCRATCH_1, 0x00ff);
 
     // Zero-extend A into D0: moveq #0, D0; move.b D4, D0
     emit_moveq_dn(block, REG_68K_D_SCRATCH_0, 0);
     emit_move_b_dn_dn(block, REG_68K_D_A, REG_68K_D_SCRATCH_0);
+
+    // Track for DAA: stash the raw operand, the borrow adjust below folds
+    // the borrow into D1 and H needs the unadjusted value
+    compile_daa_seed_operand(block, REG_68K_D_SCRATCH_1);
 
     // Add old borrow to subtrahend
     emit_btst_imm_dn(block, 0, REG_68K_D_FLAGS);
@@ -239,6 +315,9 @@ static void compile_sbc_core(struct code_block *block)
 
     // Save borrow before we clobber CCR
     emit_scc(block, 0x05, REG_68K_D_SCRATCH_1);  // scs D1: D1 = $ff if borrow
+
+    // Record H before the result overwrites old_A
+    compile_daa_store_h(block, REG_68K_D_A, REG_68K_D_SCRATCH_0, DAA_N);
 
     // Store result: move.b D0, D4
     emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_A);

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -63,7 +63,7 @@
 #define JIT_CTX_CYCLES        44  // u32: accumulated GB cycles
 #define JIT_CTX_PATCH_HELPER  48  // void *patch_helper routine
 #define JIT_CTX_READ_CYCLES   52  // u32: in-flight cycles at dmg_read call
-#define JIT_CTX_DAA_STATE     56  // 2 bytes: [0]=old_A, [1]=N flag (for DAA)
+#define JIT_CTX_DAA_STATE     56  // 2 bytes: [0]=old_A, [1]=DAA_* flags (see alu.c)
 #define JIT_CTX_FRAME_CYCLES_PTR 60  // u32 *frame_cycles_ptr (dmg->frame_cycles)
 #define JIT_CTX_STOP_FUNC   64  // void *stop_func (for STOP/speed switch)
 #define JIT_CTX_EFF_DOUBLE_SPEED 68  // u8: 1 if double speed active AND not ignored

--- a/compiler/stack.c
+++ b/compiler/stack.c
@@ -55,6 +55,34 @@ void compile_ld_sp_imm16(
     }
 }
 
+// Flags for add sp,e8 and ld hl,sp+e8: both clear Z and set C from the
+// low-byte addition with e8 treated as unsigned. Must run before SP is
+// updated - the flags come from the old SP. Clobbers D0, D1, D7.
+static void compile_sp_offset_flags(struct code_block *block, int8_t offset)
+{
+    uint8_t addend = (uint8_t) offset;
+
+    if (addend == 0) {
+        // (SP & $ff) + 0 cannot carry, so C=0, and Z=0 as always
+        emit_moveq_dn(block, REG_68K_D_FLAGS, 0);
+        return;
+    }
+
+    emit_move_w_disp_an_dn(block, JIT_CTX_GB_SP, REG_68K_A_CTX,
+            REG_68K_D_SCRATCH_0);
+    emit_andi_w_dn(block, REG_68K_D_SCRATCH_0, 0x00ff);
+    if (addend <= 8) {
+        emit_addq_w_dn(block, REG_68K_D_SCRATCH_0, addend);
+    } else {
+        emit_move_w_dn(block, REG_68K_D_SCRATCH_1, addend);
+        emit_add_w_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_SCRATCH_0);
+    }
+    emit_lsr_w_imm_dn(block, 8, REG_68K_D_SCRATCH_0);
+    // writing the 0/1 carry byte into D7 also clears Z, which is the
+    // required Z=0. X/N/V go with it and are not modelled.
+    emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_0, REG_68K_D_FLAGS);
+}
+
 // Slow path for pop: read 16-bit value via dmg_read16, result in D1.w
 // Increments gb_sp by 2 in context. Clobbers D0, D1.
 static void compile_slow_pop_to_d1(struct code_block *block)
@@ -415,6 +443,9 @@ int compile_stack_op(
             int8_t offset = (int8_t) READ_BYTE(*src_ptr);
             (*src_ptr)++;
 
+            // flags come from the old SP, so before the update
+            compile_sp_offset_flags(block, offset);
+
             if (offset != 0) {
                 // update both A3 and gb_sp
                 emit_lea_disp_an_an(block, offset, REG_68K_A_SP, REG_68K_A_SP);
@@ -433,6 +464,8 @@ int compile_stack_op(
         {
             int8_t offset = (int8_t) READ_BYTE(*src_ptr);
             (*src_ptr)++;
+
+            compile_sp_offset_flags(block, offset);
 
             // Load gb_sp from context, not A3, might be native pointer
             emit_move_w_disp_an_dn(block, JIT_CTX_GB_SP, REG_68K_A_CTX, REG_68K_D_SCRATCH_0);

--- a/compiler/stack.c
+++ b/compiler/stack.c
@@ -55,6 +55,38 @@ void compile_ld_sp_imm16(
     }
 }
 
+// D7 holds a 68k CCR (Z=$04, C=$01), not a GB F register. push af has to
+// write out the GB layout (Z=$80, C=$10, low nibble always zero) and pop af
+// has to convert back, otherwise the byte on the stack is meaningless to
+// anything but a matching push/pop pair. Both conversions are a two-bit
+// permutation, done branch-free: the bits move by 4 and 5 places, so one
+// shift plus a fixup of the bit that came out one place short.
+
+// dst = GB F byte built from the CCR in D7. Clobbers dst and tmp.
+static void compile_ccr_to_gbf(struct code_block *block, uint8_t dst, uint8_t tmp)
+{
+    emit_move_b_dn_dn(block, REG_68K_D_FLAGS, dst);
+    emit_andi_b_dn(block, dst, 0x05);       // keep CCR Z and C
+    emit_lsl_b_imm_dn(block, 4, dst);       // Z -> $40, C -> $10
+    emit_move_b_dn_dn(block, dst, tmp);
+    emit_andi_b_dn(block, tmp, 0x40);
+    emit_add_b_dn_dn(block, tmp, dst);      // doubles Z into $80
+}
+
+// D7 = CCR built from the GB F byte in src. Clobbers D7 and tmp; src is
+// preserved so the caller can still extract A from the same register. N and
+// H are dropped, they are not part of the modelled state.
+static void compile_gbf_to_ccr(struct code_block *block, uint8_t src, uint8_t tmp)
+{
+    emit_move_b_dn_dn(block, src, REG_68K_D_FLAGS);
+    emit_andi_b_dn(block, REG_68K_D_FLAGS, 0x90);  // keep GB Z and C
+    emit_lsr_b_imm_dn(block, 4, REG_68K_D_FLAGS);  // Z -> $08, C -> $01
+    emit_move_b_dn_dn(block, REG_68K_D_FLAGS, tmp);
+    emit_andi_b_dn(block, tmp, 0x08);
+    emit_lsr_b_imm_dn(block, 1, tmp);
+    emit_sub_b_dn_dn(block, tmp, REG_68K_D_FLAGS);  // halves Z into $04
+}
+
 // Flags for add sp,e8 and ld hl,sp+e8: both clear Z and set C from the
 // low-byte addition with e8 treated as unsigned. Must run before SP is
 // updated - the flags come from the old SP. Clobbers D0, D1, D7.
@@ -285,6 +317,9 @@ int compile_stack_op(
 
             // flush before the fast/slow split so both paths see the same D2
             flush_cycles(block);
+            // convert F once, ahead of the split: both paths need it, and it
+            // has to precede the tst that sets up the branch anyway
+            compile_ccr_to_gbf(block, REG_68K_D_SCRATCH_1, REG_68K_D_SCRATCH_0);
             emit_tst_l_disp_an(block, JIT_CTX_STACK_IN_RAM, REG_68K_A_CTX);
             slow_push = block->length;
             emit_beq_b(block, 0);
@@ -292,8 +327,8 @@ int compile_stack_op(
             // Fast path
             emit_subq_w_an(block, REG_68K_A_SP, 2);
             emit_subq_w_disp_an(block, 2, JIT_CTX_GB_SP, REG_68K_A_CTX);
-            // [SP] = F (low byte - flags)
-            emit_move_b_dn_ind_an(block, REG_68K_D_FLAGS, REG_68K_A_SP);
+            // [SP] = F (GB layout)
+            emit_move_b_dn_ind_an(block, REG_68K_D_SCRATCH_1, REG_68K_A_SP);
             // [SP+1] = A (high byte)
             emit_move_b_dn_disp_an(block, REG_68K_D_A, 1, REG_68K_A_SP);
             done = block->length;
@@ -303,7 +338,7 @@ int compile_stack_op(
             patch_branch_b(block, slow_push);
             emit_move_b_dn_dn(block, REG_68K_D_A, REG_68K_D_SCRATCH_0);
             emit_rol_w_8(block, REG_68K_D_SCRATCH_0);
-            emit_move_b_dn_dn(block, REG_68K_D_FLAGS, REG_68K_D_SCRATCH_0);
+            emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_SCRATCH_0);
             compile_slow_push_d0(block);
 
             patch_branch_b(block, done);
@@ -417,9 +452,9 @@ int compile_stack_op(
             slow_pop = block->length;
             emit_beq_b(block, 0);
 
-            // Fast path: sets A and F directly
+            // Fast path: sets A directly, F goes to D0 for the join below
             emit_move_b_disp_an_dn(block, 1, REG_68K_A_SP, REG_68K_D_A);  // A = [SP+1]
-            emit_move_b_ind_an_dn(block, REG_68K_A_SP, REG_68K_D_FLAGS);  // F = [SP]
+            emit_move_b_ind_an_dn(block, REG_68K_A_SP, REG_68K_D_SCRATCH_0);  // F = [SP]
             emit_addq_w_an(block, REG_68K_A_SP, 2);
             emit_addq_w_disp_an(block, 2, JIT_CTX_GB_SP, REG_68K_A_CTX);
             done = block->length;
@@ -429,12 +464,15 @@ int compile_stack_op(
             patch_branch_b(block, slow_pop);
             compile_slow_pop_to_d1(block);
             // D1.w = 0xAAFF, A = high byte, F = low byte
-            emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_FLAGS);  // F = low
+            emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_SCRATCH_0);  // F = low
             emit_rol_w_8(block, REG_68K_D_SCRATCH_1);  // D1.b = A
             emit_move_b_dn_dn(block, REG_68K_D_SCRATCH_1, REG_68K_D_A);  // A = high
 
             // Patch done branch
             patch_branch_b(block, done);
+
+            // both paths join here, so the conversion is emitted once
+            compile_gbf_to_ccr(block, REG_68K_D_SCRATCH_0, REG_68K_D_SCRATCH_1);
         }
         return 1;
 

--- a/compiler/tests/test_exec_alu.c
+++ b/compiler/tests/test_exec_alu.c
@@ -320,6 +320,74 @@ TEST(test_daa_no_adjustment)
     ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0x46);
 }
 
+// H after adc/sbc with carry-in cannot be reconstructed from old_A and the
+// result: when the operand's low nibble is $f and carry-in is set the nibble
+// sum is exactly 16, so the result's low nibble is unchanged. adc/sbc record
+// H directly instead.
+TEST(test_daa_adc_carry_in_nibble_wrap)
+{
+    // A=$96, B=$ff, carry-in 1 -> adc gives A=$96, C=1, H=1
+    // daa: +$60 (C) -> $f6, +$06 (H) -> $fc
+    uint8_t rom[] = {
+        0x3e, 0x96,       // ld a, $96
+        0x06, 0xff,       // ld b, $ff
+        0x37,             // scf -> C = 1
+        0x88,             // adc a, b -> A = $96, C = 1, H = 1
+        0x27,             // daa -> A = $fc
+        0x10              // stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0xfc);
+}
+
+TEST(test_daa_sbc_borrow_in_nibble_wrap)
+{
+    // A=$20, B=$0f, borrow-in 1 -> sbc gives A=$10, C=0, H=1
+    // daa: -$06 (H) -> $0a
+    uint8_t rom[] = {
+        0x3e, 0x20,       // ld a, $20
+        0x06, 0x0f,       // ld b, $0f
+        0x37,             // scf -> C = 1
+        0x98,             // sbc a, b -> A = $10, C = 0, H = 1
+        0x27,             // daa -> A = $0a
+        0x10              // stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0x0a);
+}
+
+TEST(test_daa_adc_carry_in_no_half_carry)
+{
+    // A=$11, B=$11, carry-in 1 -> $23, no nibble carry, so daa must not
+    // adjust (BCD: 11 + 11 + 1 = 23)
+    uint8_t rom[] = {
+        0x3e, 0x11,       // ld a, $11
+        0x06, 0x11,       // ld b, $11
+        0x37,             // scf -> C = 1
+        0x88,             // adc a, b -> A = $23, H = 0
+        0x27,             // daa -> A = $23
+        0x10              // stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0x23);
+}
+
+TEST(test_daa_adc_no_carry_in)
+{
+    // adc with carry-in clear still has to set H the ordinary way:
+    // BCD 09 + 08 = 17
+    uint8_t rom[] = {
+        0xaf,             // xor a -> C = 0
+        0x3e, 0x09,       // ld a, $09
+        0x06, 0x08,       // ld b, $08
+        0x88,             // adc a, b -> A = $11, H = 1
+        0x27,             // daa -> A = $17
+        0x10              // stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0x17);
+}
+
 // Test that dec a preserves carry flag (Pokemon Crystal xor_a_dec_a pattern)
 TEST(test_dec_a_preserves_carry)
 {
@@ -412,6 +480,10 @@ void register_alu_tests(void)
     RUN_TEST(test_daa_add_both_nibbles);
     RUN_TEST(test_daa_sub_lower_nibble);
     RUN_TEST(test_daa_no_adjustment);
+    RUN_TEST(test_daa_adc_carry_in_nibble_wrap);
+    RUN_TEST(test_daa_sbc_borrow_in_nibble_wrap);
+    RUN_TEST(test_daa_adc_carry_in_no_half_carry);
+    RUN_TEST(test_daa_adc_no_carry_in);
 
     printf("\nInc/dec carry preservation:\n");
     RUN_TEST(test_dec_a_preserves_carry);

--- a/compiler/tests/test_exec_stack.c
+++ b/compiler/tests/test_exec_stack.c
@@ -130,6 +130,57 @@ TEST(test_ld_hl_sp_plus_negative)
     ASSERT_EQ(get_areg(REG_68K_A_HL) & 0xffff, 0xdfeb);
 }
 
+// add sp,e8 and ld hl,sp+e8 both clear Z and set C from the low-byte
+// addition, with e8 treated as unsigned
+TEST(test_add_sp_flags_carry)
+{
+    uint8_t rom[] = {
+        0x31, 0xf0, 0xdf, // 0x0000: ld sp, 0xdff0
+        0xaf,             // 0x0003: xor a (Z set)
+        0xe8, 0x20,       // 0x0004: add sp, 0x20 (0xf0+0x20 carries)
+        0x10              // 0x0006: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x01);
+}
+
+TEST(test_add_sp_flags_no_carry)
+{
+    uint8_t rom[] = {
+        0x31, 0xf0, 0xdf, // 0x0000: ld sp, 0xdff0
+        0xaf,             // 0x0003: xor a (Z set)
+        0xe8, 0x05,       // 0x0004: add sp, 5 (0xf0+0x05 does not carry)
+        0x10              // 0x0006: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x00);
+}
+
+TEST(test_add_sp_flags_negative_offset)
+{
+    // e8 = -8, but C comes from the unsigned byte: 0xf0 + 0xf8 carries
+    uint8_t rom[] = {
+        0x31, 0xf0, 0xdf, // 0x0000: ld sp, 0xdff0
+        0xe8, 0xf8,       // 0x0003: add sp, -8
+        0x10              // 0x0005: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x01);
+}
+
+TEST(test_ld_hl_sp_flags)
+{
+    uint8_t rom[] = {
+        0x31, 0xf0, 0xdf, // 0x0000: ld sp, 0xdff0
+        0xaf,             // 0x0003: xor a (Z set)
+        0xf8, 0x20,       // 0x0004: ld hl, sp+0x20
+        0x10              // 0x0006: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_areg(REG_68K_A_HL) & 0xffff, 0xe010);
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x01);
+}
+
 // LD SP, HL roundtrip test
 TEST(test_ld_sp_hl_roundtrip)
 {
@@ -172,6 +223,12 @@ void register_stack_tests(void)
     RUN_TEST(test_ld_hl_sp_plus_0);
     RUN_TEST(test_ld_hl_sp_plus_positive);
     RUN_TEST(test_ld_hl_sp_plus_negative);
+
+    printf("\nSP offset flags:\n");
+    RUN_TEST(test_add_sp_flags_carry);
+    RUN_TEST(test_add_sp_flags_no_carry);
+    RUN_TEST(test_add_sp_flags_negative_offset);
+    RUN_TEST(test_ld_hl_sp_flags);
 
     printf("\nLD SP, HL roundtrip:\n");
     RUN_TEST(test_ld_sp_hl_roundtrip);

--- a/compiler/tests/test_exec_stack.c
+++ b/compiler/tests/test_exec_stack.c
@@ -73,9 +73,9 @@ TEST(test_push_af)
         0x10              // 0x0007: stop
     };
     run_program(rom, 0);
-    // H = A = 0xab, L = F = 0x04
+    // H = A = 0xab, L = F in GB layout (Z set = 0x80, not the CCR's 0x04)
     ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0xab);
-    ASSERT_EQ(get_areg(REG_68K_A_HL) & 0xffff, 0xab04);
+    ASSERT_EQ(get_areg(REG_68K_A_HL) & 0xffff, 0xab80);
 }
 
 TEST(test_pop_af)
@@ -88,8 +88,71 @@ TEST(test_pop_af)
         0x10              // 0x0005: stop
     };
     run_program(rom, 0);
+    // GB F 0x90 (Z|C) becomes the internal CCR 0x04|0x01
     ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0xcd);
-    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x90);
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x05);
+}
+
+// F crosses the stack in the GB layout, so a push/pop af pair is not the
+// only thing that can read it. These catch the CCR leaking out verbatim.
+TEST(test_push_af_pop_bc)
+{
+    uint8_t rom[] = {
+        0xaf,             // 0x0000: xor a (A=0, Z set)
+        0x3e, 0xab,       // 0x0001: ld a, 0xab (F unchanged)
+        0xf5,             // 0x0003: push af
+        0xc1,             // 0x0004: pop bc
+        0x10              // 0x0005: stop
+    };
+    run_program(rom, 0);
+    // B = A = 0xab, C = F = 0x80 (GB Z)
+    ASSERT_EQ((get_dreg(REG_68K_D_BC) >> 16) & 0xff, 0xab);
+    ASSERT_EQ(get_dreg(REG_68K_D_BC) & 0xff, 0x80);
+}
+
+TEST(test_push_bc_pop_af)
+{
+    uint8_t rom[] = {
+        0x01, 0x10, 0x34, // 0x0000: ld bc, 0x3410 (B=0x34, C=0x10 = GB C)
+        0xaf,             // 0x0003: xor a (Z set, so pop af must clear it)
+        0xc5,             // 0x0004: push bc
+        0xf1,             // 0x0005: pop af
+        0x10              // 0x0006: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0x34);
+    // GB F 0x10 is C only: CCR 0x01, Z clear
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x01);
+}
+
+// ld sp drops the stack out of native-pointer mode in the test context, so
+// these cover the slow paths of the same two opcodes
+TEST(test_push_af_slow)
+{
+    uint8_t rom[] = {
+        0x31, 0xf0, 0xdf, // 0x0000: ld sp, 0xdff0 (slow mode)
+        0xaf,             // 0x0003: xor a (Z set)
+        0x3e, 0xab,       // 0x0004: ld a, 0xab
+        0xf5,             // 0x0006: push af
+        0xe1,             // 0x0007: pop hl
+        0x10              // 0x0008: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_areg(REG_68K_A_HL) & 0xffff, 0xab80);
+}
+
+TEST(test_pop_af_slow)
+{
+    uint8_t rom[] = {
+        0x31, 0xf0, 0xdf, // 0x0000: ld sp, 0xdff0 (slow mode)
+        0x21, 0x90, 0xcd, // 0x0003: ld hl, 0xcd90 (A=0xcd, F=0x90)
+        0xe5,             // 0x0006: push hl
+        0xf1,             // 0x0007: pop af
+        0x10              // 0x0008: stop
+    };
+    run_program(rom, 0);
+    ASSERT_EQ(get_dreg(REG_68K_D_A) & 0xff, 0xcd);
+    ASSERT_EQ(get_dreg(REG_68K_D_FLAGS) & 0xff, 0x05);
 }
 
 // LD HL, SP+n tests
@@ -218,6 +281,10 @@ void register_stack_tests(void)
     printf("\nPush/pop AF:\n");
     RUN_TEST(test_push_af);
     RUN_TEST(test_pop_af);
+    RUN_TEST(test_push_af_pop_bc);
+    RUN_TEST(test_push_bc_pop_af);
+    RUN_TEST(test_push_af_slow);
+    RUN_TEST(test_pop_af_slow);
 
     printf("\nLD HL, SP+n:\n");
     RUN_TEST(test_ld_hl_sp_plus_0);

--- a/compiler/tests/tests.h
+++ b/compiler/tests/tests.h
@@ -13,7 +13,7 @@
 #define REG_A   0x0004  // D4, 8-bit
 #define REG_BC  0x0105  // D5, split (0x00BB00CC)
 #define REG_DE  0x0106  // D6, split (0x00DD00EE)
-#define REG_F   0x0007  // D7, 8-bit (flags: Z=0x80, N=0x40, H=0x20, C=0x10)
+#define REG_F   0x0007  // D7, 8-bit (internal 68k CCR: Z=0x04, C=0x01; N/H not modelled)
 #define REG_HL  0x0212  // A2, 16-bit contiguous (0xHHLL)
 #define REG_SP  0x0213  // A3, 16-bit contiguous
 


### PR DESCRIPTION
Three SM83 correctness fixes in the JIT, found via SingleStepTests/sm83 with H and N masked out. All three were hidden due to H/N not being tracked: `compat/baseline.txt` records `cpu_instrs` failing 10 of 11 tests, and blargg CRCs both A and F, so with H/N unmodelled the baseline cannot distinguish a wrong result or a wrong Z/C from the known H/N gap.

I was actually attempting to fix some graphical issues in some rom hacks a couple days ago, but found these along the way. No games I am aware of get unlocked by these fixes, but they are useful nonetheless.

Your choice on whether to include them. The Pop_AF/Push_AF one was wrong in both the pop/push so its behavior was hidden, I think this bug is only visible when manually inspecting the stack.

Side note - Not sure if H/N can easily be added because the 68k doesn't have an equivalent, but maybe it could improve compatibility?

 ### In-game performance diff

  | ROM | frames | 68k insn before | after | Δ | code bytes Δ |
  |---|---|---|---|---|---|
  | Tetris (scripted into gameplay) | 2400 | 211,525,978 | 211,527,766 |**+0.0008%** | +0.04% |
  | Metroid II | 900 | 1,429,876 | 1,429,885 | +0.0006% | +0.29% |
  | 2048 | 900 | 274,702 | 274,728 | +0.0095% | +3.26% |
  | blargg cpu_instrs | 900 | 115,035 | 115,061 | +0.0226% | +1.29% |
  | Pokémon Crystal | 900 | 1,621,086 | 1,623,186 | +0.1295% | +1.93% |
  | Kirby | 900 | 356,450 | 357,792 | +0.3765% | +1.77% |